### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ python
 
 # Get into python environment
 import latex2sympy2
-import Flask
+import flask
 ```
 
 ## Usage


### PR DESCRIPTION
When importing in python you don't use capital letters, even when the package name has one.